### PR TITLE
feat: expose pairings over web server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Debug binaries
+__debug*
+
+# Scratch files for local testing
+scratch.http

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Server",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}"
+        }
+    ]
+}

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -1,0 +1,73 @@
+package application
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/cdriehuys/secret-santa/internal/pairings"
+)
+
+const MaxNames = 100
+const MaxExclusions = 3
+
+type GiftRestrictions map[string][]string
+
+type pairingGenerator func(GiftRestrictions) ([]pairings.Pairing, error)
+
+type Application struct {
+	Logger *slog.Logger
+
+	PairingGenerator pairingGenerator
+}
+
+func (s *Application) Routes() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /pairings", s.pairingsPost)
+
+	return mux
+}
+
+func (s *Application) pairingsPost(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	restrictions := GiftRestrictions{}
+
+	for i := range MaxNames {
+		nameKey := fmt.Sprintf("name[%d]", i)
+		name := r.FormValue(nameKey)
+
+		if name == "" {
+			break
+		}
+
+		var exclusions []string
+		for j := range MaxExclusions {
+			exclusionKey := fmt.Sprintf("%s.exclusion[%d]", nameKey, j)
+			exclusion := r.FormValue(exclusionKey)
+
+			if exclusion == "" {
+				break
+			}
+
+			exclusions = append(exclusions, exclusion)
+		}
+
+		restrictions[name] = exclusions
+	}
+
+	pairs, err := s.PairingGenerator(restrictions)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprintln(w, "Pairings:")
+	for _, pair := range pairs {
+		fmt.Fprintf(w, "%s -> %s\n", pair.From, pair.To)
+	}
+}

--- a/internal/application/application_test.go
+++ b/internal/application/application_test.go
@@ -1,0 +1,97 @@
+package application_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/cdriehuys/secret-santa/internal/application"
+	"github.com/cdriehuys/secret-santa/internal/application/testutils"
+	"github.com/cdriehuys/secret-santa/internal/pairings"
+)
+
+func TestApplication_pairingsPost(t *testing.T) {
+	names := []string{"Bob", "Jane"}
+	fakeGenerator := func(restrictions application.GiftRestrictions) ([]pairings.Pairing, error) {
+		pairs := []pairings.Pairing{
+			{From: "Bob", To: "Jane"},
+			{From: "Jane", To: "Bob"},
+		}
+
+		return pairs, nil
+	}
+
+	app := testutils.NewTestApplication(t)
+	app.PairingGenerator = fakeGenerator
+
+	ts := testutils.NewTestServer(t, app.Routes())
+	defer ts.Close()
+
+	form := url.Values{}
+	for i, name := range names {
+		form.Add(fmt.Sprintf("name[%d]", i), name)
+	}
+
+	res := ts.PostForm(t, "/pairings", form)
+
+	if got := res.Status; got != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, got)
+	}
+
+	assertContains(t, res.Body, "Bob -> Jane")
+	assertContains(t, res.Body, "Jane -> Bob")
+}
+
+func TestApplication_pairingsPostWithExclusions(t *testing.T) {
+	people := map[string][]string{
+		"Ross":     {"Joey"},
+		"Joey":     {"Chandler"},
+		"Chandler": {"Ross"},
+	}
+
+	fakeGenerator := func(application.GiftRestrictions) ([]pairings.Pairing, error) {
+		pairs := []pairings.Pairing{
+			{From: "Ross", To: "Chandler"},
+			{From: "Joey", To: "Ross"},
+			{From: "Chandler", To: "Joey"},
+		}
+
+		return pairs, nil
+	}
+
+	app := testutils.NewTestApplication(t)
+	app.PairingGenerator = fakeGenerator
+
+	ts := testutils.NewTestServer(t, app.Routes())
+	defer ts.Close()
+
+	form := url.Values{}
+	i := 0
+	for person, restrictions := range people {
+		form.Add(fmt.Sprintf("name[%d]", i), person)
+
+		for j, restriction := range restrictions {
+			form.Add(fmt.Sprintf("name[%d].exclusion[%d]", i, j), restriction)
+		}
+
+		i++
+	}
+
+	res := ts.PostForm(t, "/pairings", form)
+
+	if got := res.Status; got != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, got)
+	}
+
+	assertContains(t, res.Body, "Ross -> Chandler")
+	assertContains(t, res.Body, "Joey -> Ross")
+	assertContains(t, res.Body, "Chandler -> Joey")
+}
+
+func assertContains(t *testing.T, haystack string, needle string) {
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("Expected to find %q in %q", needle, haystack)
+	}
+}

--- a/internal/application/testutils/testutils.go
+++ b/internal/application/testutils/testutils.go
@@ -1,0 +1,85 @@
+package testutils
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/cdriehuys/secret-santa/internal/application"
+)
+
+func NewTestApplication(t *testing.T) *application.Application {
+	return &application.Application{
+		Logger: slog.New(slog.DiscardHandler),
+	}
+}
+
+type TestServer struct {
+	*httptest.Server
+}
+
+func NewTestServer(t *testing.T, h http.Handler) *TestServer {
+	ts := httptest.NewServer(h)
+
+	return &TestServer{ts}
+}
+
+type TestResponse struct {
+	Status  int
+	Headers http.Header
+	Cookies []*http.Cookie
+	Body    string
+}
+
+func MakeTestResponse(t *testing.T, res *http.Response) TestResponse {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	return TestResponse{
+		Status:  res.StatusCode,
+		Headers: res.Header,
+		Cookies: res.Cookies(),
+		Body:    string(bytes.TrimSpace(body)),
+	}
+}
+
+func (ts *TestServer) Get(t *testing.T, path string) TestResponse {
+	req := ts.makeRequest(t, http.MethodGet, path, nil)
+
+	return ts.doRequest(t, req)
+}
+
+func (ts *TestServer) PostForm(t *testing.T, path string, form url.Values) TestResponse {
+	req := ts.makeRequest(t, http.MethodPost, path, strings.NewReader(form.Encode()))
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return ts.doRequest(t, req)
+}
+
+func (ts *TestServer) makeRequest(t *testing.T, method string, path string, body io.Reader) *http.Request {
+	req, err := http.NewRequest(method, ts.URL+path, body)
+	if err != nil {
+		t.Fatalf("failed to create %s request to %q: %v", method, path, err)
+	}
+
+	return req
+}
+
+func (ts *TestServer) doRequest(t *testing.T, req *http.Request) TestResponse {
+	res, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("failed to send %s request to %q: %v", req.Method, req.URL.Path, err)
+	}
+
+	defer res.Body.Close()
+
+	return MakeTestResponse(t, res)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/cdriehuys/secret-santa/internal/application"
+	"github.com/cdriehuys/secret-santa/internal/pairings"
+)
+
+func main() {
+	logger := slog.New(
+		slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}),
+	)
+
+	pairingGenerator := func(restrictions application.GiftRestrictions) ([]pairings.Pairing, error) {
+		graph := pairings.NewGraphFromExclusions(restrictions)
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+		return graph.Pairings(r)
+	}
+
+	app := application.Application{
+		Logger:           logger,
+		PairingGenerator: pairingGenerator,
+	}
+
+	s := http.Server{
+		Addr:    ":8080",
+		Handler: app.Routes(),
+	}
+
+	if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("Server stopped.", "error", err)
+	}
+}


### PR DESCRIPTION
Add a minimal web server that allows for generating pairings through a POST request.
